### PR TITLE
Contact Us Form and Privacy Agreement Page

### DIFF
--- a/backend/root/templates/core/contactus.html
+++ b/backend/root/templates/core/contactus.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact Us</title>
+    <style>
+        body {
+            margin: 0;
+            font-family: Arial, sans-serif;
+            background-color: #97c39b;
+        }
+        .container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+        .form-box {
+            background-color: white;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+            width: 350px;
+            text-align: center;
+        }
+        .form-box h2 {
+            color: #1b4d1e;
+        }
+        .uplant-email {
+            margin-bottom: 15px;
+            font-size: 14px;
+            color: #1b4d1e;
+        }
+        .form-group {
+            margin-bottom: 15px;
+            text-align: left;
+        }
+        label {
+            display: block;
+            color: #333;
+            font-weight: bold;
+        }
+        input, textarea {
+            width: 100%;
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 5px;
+            font-size: 14px;
+        }
+        .submit-btn {
+            background-color: #1b4d1e;
+            color: white;
+            padding: 10px;
+            width: 100%;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        .submit-btn:hover {
+            background-color: #145a18;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="form-box">
+            <h2>Contact Us</h2>
+            <p class="uplant-email">U-Plant Email: <strong>temp@gmail.com</strong></p>
+            <form method="post">
+                {% csrf_token %}
+                <div class="form-group">
+                    <label for="id_name">Name</label>
+                    {{ form.name }}
+                </div>
+                
+                <div class="form-group">
+                    <label for="id_subject">Subject</label>
+                    {{ form.subject }}
+                </div>
+                
+                <div class="form-group">
+                    <label for="id_message">Description</label>
+                    {{ form.message }}
+                </div>
+
+                <button type="submit" class="submit-btn">Send Message</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/root/templates/core/privacyagreement.html
+++ b/backend/root/templates/core/privacyagreement.html
@@ -1,0 +1,100 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Agreement</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #97c39b;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+        }
+        .container {
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+            width: 400px;
+            text-align: center;
+        }
+        h2 {
+            color: #1b4d1e;
+        }
+        .privacy-text {
+            text-align: left;
+            font-size: 14px;
+            color: #333;
+            border: 1px solid #ccc;
+            padding: 10px;
+            height: 200px;
+            overflow-y: scroll;
+            background-color: #f9f9f9;
+            margin-bottom: 15px;
+            border-radius: 5px;
+        }
+        .checkbox-container {
+            text-align: left;
+            font-size: 14px;
+            margin-bottom: 15px;
+        }
+        .submit-btn {
+            background-color: #1b4d1e;
+            color: white;
+            padding: 10px;
+            width: 100%;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 16px;
+        }
+        .submit-btn:disabled {
+            background-color: gray;
+            cursor: not-allowed;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h2>Privacy Agreement</h2>
+        <div class="privacy-text">
+            <p>
+                We take your privacy seriously. By using our service, you agree to the following:
+            </p>
+            <ul>
+                <li>Your username and password will be securely encrypted.</li>
+                <li>Your zip code will be used for personalized information services.</li>
+                <li>We do not share your personal data with third parties.</li>
+                <li>Your usage data may be collected for service improvements.</li>
+            </ul>
+            <p>
+                By checking the box below, you acknowledge and accept U-Plant's privacy policy.
+            </p>
+        </div>
+
+        <div class="checkbox-container">
+            <input type="checkbox" id="agreeCheckbox"> 
+            <label for="agreeCheckbox">I agree to the Privacy Policy</label>
+        </div>
+
+        <button id="submitBtn" class="submit-btn" disabled>Continue</button>
+    </div>
+
+    <script>
+        // Enable the submit button when the checkbox is checked
+        document.getElementById("agreeCheckbox").addEventListener("change", function() {
+            document.getElementById("submitBtn").disabled = !this.checked;
+        });
+
+        // Redirect to the main dashboard on submit
+        document.getElementById("submitBtn").addEventListener("click", function() {
+            window.location.href = "/dashboard"; // Needs to be the actual dashboard url I couldnt find it
+        });
+    </script>
+</body>
+</html>

--- a/backend/root/user_management/forms.py
+++ b/backend/root/user_management/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
 from django.utils.translation import gettext_lazy as _
 from user_management.models import User
+from django.core.mail import send_mail
 
 class CustomUserCreationForm(UserCreationForm):
     class Meta(UserCreationForm.Meta):
@@ -42,3 +43,18 @@ class CustomPasswordChangeForm(forms.ModelForm):
         if new_password and confirm_password and new_password != confirm_password:
             self.add_error('confirm_password', 'New password and Confirm new password do not match')
         return cleaned_data
+    
+    # Cainan work from 3/12
+    class ContactForm(forms.Form):
+        name = forms.CharField(
+            max_length=100, 
+            widget=forms.TextInput(attrs={'placeholder': 'Enter your name', 'class': 'form-control'})
+        )
+        subject = forms.CharField(
+            max_length=100, 
+            widget=forms.TextInput(attrs={'placeholder': 'Enter subject', 'class': 'form-control'})
+        )
+        message = forms.CharField(
+            widget=forms.Textarea(attrs={'placeholder': 'Describe your problem', 'class': 'form-control', 'rows': 4})
+        )
+        #END

--- a/backend/root/user_management/urls.py
+++ b/backend/root/user_management/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, reverse_lazy
 from django.contrib.auth import views as auth_views
-from user_management.views import UserCreateView, UserUpdateView, UserListView, UserDetailView, UserDeleteView
+from user_management.views import UserCreateView, UserUpdateView, UserListView, UserDetailView, UserDeleteView,ContactUsView
 
 urlpatterns = [
     path('create/', UserCreateView.as_view(), name='create_user'),
@@ -8,4 +8,5 @@ urlpatterns = [
     path('', UserListView.as_view(), name='user_list'),
     path('user/<int:pk>/', UserDetailView.as_view(), name='user_detail'),
     path('delete/<int:pk>/', UserDeleteView.as_view(), name='user_confirm_delete'),  # Added delete path
+    path("contact/", ContactUsView.as_view(), name="contact_us"),
 ]

--- a/backend/root/user_management/views.py
+++ b/backend/root/user_management/views.py
@@ -6,6 +6,12 @@ from user_management.models import User
 from django.core.mail import send_mail
 from django.db.models import Q, Count
 
+# Cainan work from 3/12
+from django.shortcuts import render, redirect
+from .forms import ContactForm
+from django.views import View
+#END
+
 
 class UserDeleteView(LoginRequiredMixin, UserPassesTestMixin, DeleteView):
     model = User
@@ -64,3 +70,30 @@ class UserDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
         context = super().get_context_data(**kwargs)
         return context
     
+# Cainan work from 3/12
+    
+class ContactUsView(LoginRequiredMixin, View):
+    def get(self, request):
+        form = ContactForm()
+        return render(request, "contact_us.html", {"form": form})
+
+    def post(self, request):
+        form = ContactForm(request.POST)
+        if form.is_valid():
+            name = form.cleaned_data['name']
+            subject = form.cleaned_data['subject']
+            message = form.cleaned_data['message']
+            user_email = request.user.email  
+
+            full_message = f"From: {name} ({user_email})\n\n{message}"
+
+            send_mail(
+                subject=f"New Contact Form Submission: {subject}",
+                message=full_message,
+                from_email=user_email,  
+                recipient_list=["uplant@gmail.com"],  # This needs to be whatever our email is
+            )
+            return redirect("/dashboard")  #needs to be the actual dashboard url i couldnt find it
+
+        return render(request, "contact_us.html", {"form": form})
+    #END


### PR DESCRIPTION
This is what I currently have for the contact us form and the privacy agreement page.  On  views.py, I didn't know what the uplant email is so I put a place holder and I also couldn't find the home page url so that also has a placeholder.  On  privacyagreement.html there is also a link to the dashboard that needs to be updated with the real url.  We can change the appearance of the pages but I just wanted to get something out there